### PR TITLE
Installer options and acceptable return codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This file is used to list changes made in each version of visualstudion.
 
+## 1.2.5
+
+* Added the attribute for additional "success" return codes
+* Fix deprecations and formatting
+* Backported updated metadata from upstream community cookbook
+
 ## 1.2.4
 
 * Allow for overriding install dir on a per-edition basis

--- a/attributes/vs2017.rb
+++ b/attributes/vs2017.rb
@@ -26,6 +26,9 @@ default['visualstudio']['2017']['allWorkloads'] = false
 default['visualstudio']['2017']['includeRecommended'] = true
 default['visualstudio']['2017']['includeOptional'] = false
 
+# Added to allow override for error code 1 and similar
+default['visualstudio']['2017']['additional_success_codes'] = []
+
 # Test Professional w/Update1 https://docs.microsoft.com/en-us/visualstudio/install/workload-component-id-vs-test-professional
 default['visualstudio']['2017']['testprofessional']['installer_file'] = 'vs_testprofessional.exe'
 default['visualstudio']['2017']['testprofessional']['filename'] = 'vs_testprofessional.exe'

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -1,0 +1,6 @@
+
+
+module VisualStudio
+  # Constant with the default return codes for vs2017 installer
+  VS_2017_SUCCESS_CODES = [0, 127, 3010].freeze
+end

--- a/libraries/helper.rb
+++ b/libraries/helper.rb
@@ -35,6 +35,14 @@ module Visualstudio
       url
     end
 
+    def installer_success_codes(version)
+      if node['visualstudio'][version].key? 'additional_success_codes'
+        VisualStudio::VS_2017_SUCCESS_CODES + node['visualstudio'][version]['additional_success_codes']
+      else
+        VisualStudio::VS_2017_SUCCESS_CODES
+      end
+    end
+
     private
 
     # Gets the version/edition ISO download root URL

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,11 +1,14 @@
+    
 name             'visualstudio'
 maintainer       'Shawn Neal'
 maintainer_email 'sneal@sneal.net'
-source_url       'https://github.com/windowschefcookbooks/visualstudio'
-issues_url       'https://github.com/windowschefcookbooks/visualstudio/issues'
-license          'Apache 2.0'
+source_url       'https://github.com/Roblox/visualstudio'
+issues_url       'https://github.com/Roblox/visualstudio/issues'
+chef_version     '>= 13.0' if respond_to?(:chef_version)
+license          'Apache-2.0'
 description      'Installs/Configures Visual Studio'
-version          '1.2.4'
-
-depends          'seven_zip'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version          '2.0.0'
+supports         'windows'
 depends          'windows'
+depends          'seven_zip'

--- a/providers/update.rb
+++ b/providers/update.rb
@@ -20,6 +20,7 @@
 #
 
 require 'digest/md5'
+require 'chef/util/path_helper'
 
 include Windows::Helper
 include Visualstudio::Helper
@@ -47,7 +48,7 @@ action :install do
         installer_type :custom
         options "/Q /norestart /noweb /Log \"#{install_log_file}\""
         timeout 3600 # 1 hour
-        success_codes [0, 127, 3010]
+        returns new_resource.success_codes
       end
 
       # Cleanup extracted ISO files
@@ -58,7 +59,6 @@ action :install do
         not_if { new_resource.preserve_extracted_files }
       end
     end
-    new_resource.updated_by_last_action(true)
   end
 end
 
@@ -68,11 +68,11 @@ def extracted_iso_dir
     Digest::MD5.hexdigest(new_resource.package_name)
   )
   extract_dir = node['visualstudio']['unpack_dir'].nil? ? default_path : node['visualstudio']['unpack_dir']
-  win_friendly_path(extract_dir)
+  Chef::Util::PathHelper.cleanpath(extract_dir)
 end
 
 def install_log_file
-  win_friendly_path(::File.join(new_resource.install_dir, 'vsinstallupdate.log'))
+  Chef::Util::PathHelper.cleanpath(::File.join(new_resource.install_dir, 'vsinstallupdate.log'))
 end
 
 # only base file name of source, e.g. VS2013.5

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -28,17 +28,19 @@ installs.each do |install|
   url = source_download_url(version, edition)
   # allow to override the install dir on a per-edition basis
   install_directory = node['visualstudio'][version][edition]['install_dir'] || node['visualstudio'][version]['install_dir'] # rubocop:disable Metrics/LineLength
+  combined_success_codes = installer_success_codes(version)
 
   visualstudio_edition "visualstudio_#{version}_#{edition}" do
-    edition edition
-    version version
+    edition     edition
+    version     version
     install_dir install_directory
-    source url
-    product_key node['visualstudio'][version][edition]['product_key']
-    package_name node['visualstudio'][version][edition]['package_name']
-    checksum node['visualstudio'][version][edition]['checksum']
-    preserve_extracted_files node['visualstudio']['preserve_extracted_files']
-    installer_file node['visualstudio'][version][edition]['installer_file']
-    configure_basename node['visualstudio'][version][edition]['config_file'] if version == '2010'
+    source      url
+    success_codes combined_success_codes if version == '2017'
+    product_key   node['visualstudio'][version][edition]['product_key']
+    package_name  node['visualstudio'][version][edition]['package_name']
+    checksum      node['visualstudio'][version][edition]['checksum']
+    preserve_extracted_files  node['visualstudio']['preserve_extracted_files']
+    installer_file            node['visualstudio'][version][edition]['installer_file']
+    configure_basename        node['visualstudio'][version][edition]['config_file'] if version == '2010'
   end
 end

--- a/recipes/install_update.rb
+++ b/recipes/install_update.rb
@@ -27,11 +27,14 @@ versions_with_updates = versions.reject { |v| node['visualstudio'][v]['update'].
 # Install updates for each VS version
 versions_with_updates.each do |version|
   url = source_download_url(version, 'update')
+  combined_success_codes = installer_success_codes(version)
+
   visualstudio_update "visualstudio_#{version}_update" do
-    install_dir node['visualstudio'][version]['install_dir']
-    source url
-    package_name node['visualstudio'][version]['update']['package_name']
-    checksum node['visualstudio'][version]['update']['checksum']
+    install_dir   node['visualstudio'][version]['install_dir']
+    source        url
+    package_name  node['visualstudio'][version]['update']['package_name']
+    checksum      node['visualstudio'][version]['update']['checksum']
+    success_codes combined_success_codes if version == '2017'
     preserve_extracted_files node['visualstudio']['preserve_extracted_files']
   end
 end

--- a/recipes/install_vsto.rb
+++ b/recipes/install_vsto.rb
@@ -19,12 +19,14 @@
 # limitations under the License.
 #
 
+require 'chef/util/path_helper'
+
 ::Chef::Recipe.send(:include, Visualstudio::Helper)
 
 # Install VSTO for each VS version
 versions.each do |version|
   if version == '2012'
-    install_log_path = win_friendly_path(
+    install_log_path = Chef::Util::PathHelper.cleanpath(
       File.join(node['visualstudio']['2012']['install_dir'], 'vstoinstall.log')
     )
 

--- a/resources/edition.rb
+++ b/resources/edition.rb
@@ -51,3 +51,5 @@ attribute :installer_file, kind_of: String, required: false
 
 # VS 2010 ini path, unused for 2013+
 attribute :configure_basename, kind_of: String, default: nil
+
+attribute :success_codes, kind_of: [Array], default: VisualStudio::VS_2017_SUCCESS_CODES

--- a/resources/update.rb
+++ b/resources/update.rb
@@ -36,3 +36,5 @@ attribute :checksum, kind_of: String
 
 # Should the extracted ISO files be preserved after installation?
 attribute :preserve_extracted_files, kind_of: [TrueClass, FalseClass], default: false
+
+attribute :success_codes, kind_of: [Array], default: VisualStudio::VS_2017_SUCCESS_CODES


### PR DESCRIPTION
* Changed installer options back to `--quiet` from `--passive` to factor out GUI interactions
* Added `1` to a list of acceptable exit codes to unblock converges;
It might have undesirable side effects but the "official" meaning of error code 1 is "no fatal errors"
* Fixed deprecations: replaced `win_friendly_path` with `Chef::Util::PathHelper.cleanpath`
* Fixed formatting in the actual recipes for better readability
* Backported updated metadata from upstream community cookbook