### PR TITLE
Add `:modify` action to VS 2017 resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This file is used to list changes made in each version of visualstudion.
 
+## 2.0.0
+
+* Add the `:modify` action to VS2017 resource/provider
+* Major version update as the support for Chef 12 is dropped in a previous commit
+* `use_inline_resources` is removed as it is default in Chef 13+
+
 ## 1.2.6
 
 * Add test kitchen with test policy and dummy tests

--- a/libraries/helper.rb
+++ b/libraries/helper.rb
@@ -1,5 +1,3 @@
-
-
 module Visualstudio
   # VS cookbook library helper methods
   module Helper
@@ -17,7 +15,7 @@ module Visualstudio
       return node['visualstudio']['installs'] unless node['visualstudio']['installs'].nil?
       [{
         'edition' => node['visualstudio']['edition'],
-        'version' => node['visualstudio']['version']
+        'version' => node['visualstudio']['version'],
       }]
     end
 
@@ -73,6 +71,26 @@ module Visualstudio
         end
       end
       false
+    end
+
+    # Inspired by https://github.com/btc-ag/chef-vs2017/blob/develop/libraries/vs2017.rb
+    def vs2017_vswhere(edition, property)
+      vswhere_exe = '"C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe"'
+
+      # make first character uppercase
+      product = edition.sub(/\S/, &:upcase)
+      cmd = Chef::Mixlib::ShellOut.new(
+        "#{vswhere_exe} -all -version [15.0,16.0) -property #{property} -products Microsoft.VisualStudio.Product.#{product}",
+        returns: [0, 1]
+      )
+      cmd.run_command
+      cmd.error!
+      cmd
+    end
+
+    def vs2017_edition_installed?(edition)
+      cmd = vs2017_vswhere(edition, 'installationVersion')
+      cmd.stderr.empty? && (cmd.stdout =~ /^15./)
     end
 
     def uninstall_reg_key

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,4 +1,4 @@
-    
+
 name             'visualstudio'
 maintainer       'Shawn Neal'
 maintainer_email 'sneal@sneal.net'
@@ -8,7 +8,7 @@ chef_version     '>= 13.0' if respond_to?(:chef_version)
 license          'Apache-2.0'
 description      'Installs/Configures Visual Studio'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.2.6'
+version          '2.0.0'
 supports         'windows'
 depends          'windows'
 depends          'seven_zip'

--- a/providers/update.rb
+++ b/providers/update.rb
@@ -29,8 +29,6 @@ def whyrun_supported?
   true
 end
 
-use_inline_resources
-
 action :install do
   unless package_is_installed?(new_resource.package_name)
     converge_by("Installing #{new_resource.package_name}") do

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -30,7 +30,11 @@ installs.each do |install|
   install_directory = node['visualstudio'][version][edition]['install_dir'] || node['visualstudio'][version]['install_dir'] # rubocop:disable Metrics/LineLength
   combined_success_codes = installer_success_codes(version)
 
+  action = :install
+  action = :modify if version == '2017' && vs2017_edition_installed?(edition)
+
   visualstudio_edition "visualstudio_#{version}_#{edition}" do
+    action      action
     edition     edition
     version     version
     install_dir install_directory

--- a/resources/edition.rb
+++ b/resources/edition.rb
@@ -19,7 +19,7 @@
 # limitations under the License.
 #
 
-actions :install
+actions :install, :modify
 default_action :install
 
 # The VS edition: professional etc

--- a/test/policyfiles/base_test.rb
+++ b/test/policyfiles/base_test.rb
@@ -9,10 +9,10 @@ run_list.push(
 )
 
 #
-# Attributes
+# Attributes for VS 2017
 #
-# Uncomment the overrides to test specific parts of functionality. 
-# WIP to turn into a proper test suite
+
+# default['visualstudio']['preserve_extracted_files'] = true
 #
 # override['visualstudio']['2017']['additional_success_codes'] = [1]
 # override['visualstudio']['installs'] = [


### PR DESCRIPTION
* Add the `:modify` action to VS2017 resource/provider
* Major version update as the support for Chef 12 is dropped in a previous commit
* `use_inline_resources` is removed as it is default in Chef 13+
* Add the auto-detection of install vs modify
* Add helper methods to check for installed VS 2017 versions
* Add the logic to choose an action to `install` recipe